### PR TITLE
Rnaseqconcatenate

### DIFF
--- a/tool-data/bowtie2_indices.loc
+++ b/tool-data/bowtie2_indices.loc
@@ -1,0 +1,40 @@
+# bowtie2_indices.loc.sample
+# This is a *.loc.sample file distributed with Galaxy that enables tools
+# to use a directory of indexed data files. This one is for Bowtie2 and Tophat2.
+# See the wiki: http://wiki.galaxyproject.org/Admin/NGS%20Local%20Setup
+# First create these data files and save them in your own data directory structure.
+# Then, create a bowtie_indices.loc file to use those indexes with tools.
+# Copy this file, save it with the same name (minus the .sample), 
+# follow the format examples, and store the result in this directory.
+# The file should include an one line entry for each index set.
+# The path points to the "basename" for the set, not a specific file.
+# It has four text columns seperated by TABS.
+#
+# <unique_build_id>	<dbkey>	<display_name>	<file_base_path>
+#
+# So, for example, if you had hg18 indexes stored in:
+#
+#    /depot/data2/galaxy/hg19/bowtie2/
+#
+# containing hg19 genome and hg19.*.bt2 files, such as:
+#    -rw-rw-r-- 1 james   james   914M Feb 10 18:56 hg19canon.fa
+#    -rw-rw-r-- 1 james   james   914M Feb 10 18:56 hg19canon.1.bt2
+#    -rw-rw-r-- 1 james   james   683M Feb 10 18:56 hg19canon.2.bt2
+#    -rw-rw-r-- 1 james   james   3.3K Feb 10 16:54 hg19canon.3.bt2
+#    -rw-rw-r-- 1 james   james   683M Feb 10 16:54 hg19canon.4.bt2
+#    -rw-rw-r-- 1 james   james   914M Feb 10 20:45 hg19canon.rev.1.bt2
+#    -rw-rw-r-- 1 james   james   683M Feb 10 20:45 hg19canon.rev.2.bt2
+#
+# then the bowtie2_indices.loc entry could look like this:
+#
+#hg19	hg19	Human (hg19)	/depot/data2/galaxy/hg19/bowtie2/hg19canon
+#
+#More examples:
+#
+#mm10	mm10	Mouse (mm10)	/depot/data2/galaxy/mm10/bowtie2/mm10
+#dm3	dm3		D. melanogaster (dm3)	/depot/data2/galaxy/mm10/bowtie2/dm3
+#
+#
+#genome	genome	Human	/data/genomes/rna_from_ohsu/bt2/genome
+genome	genome	Homo_sapiens	/opt/Genomics/ohsu/dnapipeline/homosapiensrefgenome/Homo_sapiens_assembly19
+

--- a/tool_conf.xml
+++ b/tool_conf.xml
@@ -260,6 +260,8 @@
 	    <tool file="cufflinks/cuffmerge_wrapper.xml" />
 	    <tool file="cufflinks/cufflinks_wrapper.xml" />
 	    <tool file="cufflinks/cuffdiff_wrapper.xml" />
+     <label id="concatenate_files" text="Concatenate 1.0.0" />
+             <tool file="concatenate/concatenate_wrapper.xml" />
   </section>  
   <section id="cbioportal_tools" name="cBioPortal Tools">
     <tool file="cbioportal/cbioportal_create_files.xml" />

--- a/tools/concatenate/concatenate_wrapper.py
+++ b/tools/concatenate/concatenate_wrapper.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python
+
+import sys, argparse, os, subprocess, shutil
+
+def __main__():
+
+    #Parse Command Line
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument( 'outfile', action='store', type=str, help='Output file name for concatenated files' )
+    parser.add_argument( 'infiles', action='store', type=str, nargs='+', help='Input file names to concatenate separated by spaces' )
+
+ 
+    options = parser.parse_args()
+    outfile = options.outfile
+    print outfile 
+    infiles = options.infiles
+    print infiles
+    
+    # if there is more than 1 input file
+    # concatenate the files to produce one result file
+    # if there are multiple gzipped input files this will result
+    # in one gzipped file 
+    if len(infiles) > 1:
+#      cmdline = "zcat "
+       cmdline = "cat "
+       for inp in infiles:
+          cmdline = cmdline + inp + " "
+#         cmdline = cmdline + "| gzip >" + outfile
+       cmdline = cmdline + " >" + outfile
+       print cmdline
+       try:
+          subprocess.check_output(args=cmdline, stderr=subprocess.STDOUT, shell=True)
+       except subprocess.CalledProcessError, e:
+          print "!!!!!!!!!!!!concatenate ERROR: stdout output:\n", e.output
+
+if __name__=="__main__": __main__()
+

--- a/tools/concatenate/concatenate_wrapper.xml
+++ b/tools/concatenate/concatenate_wrapper.xml
@@ -1,0 +1,67 @@
+<tool id="concatenate_files" name="Concatenate fastq" version="1.0.0">
+    <description>Concatenate files using cat</description>
+    <requirements>
+        <container type="docker">concatenate_files:1.0.0</container>
+    </requirements>
+    <command interpreter="python">
+        concatenate_wrapper.py 
+        $out_file1
+        #set inputs = ' '.join( [ str( $inp ) for $inp in $input1 ] )
+        $inputs
+    </command>
+    <inputs>
+        <param name="input1" type="data" label="Concatenate Dataset" multiple="true" />
+    </inputs>
+    <outputs>
+        <data name="out_file1" format="fastqsanger" metadata_source="input1"/> 
+    </outputs>
+    <tests>
+        <test>
+            <param name="input1" value="test.txt test2.txt"/>
+            <output name="out_file1" file="concatenated_files.txt"/>
+        </test>
+    </tests>
+    <help>
+
+.. class:: warningmark
+
+**WARNING:** Be careful not to concatenate datasets of different kinds (e.g., sequences with intervals). This tool does not check if the datasets being concatenated are in the same format. 
+
+-----
+
+**What it does**
+
+Concatenates datasets
+
+-----
+
+**Example**
+
+Concatenating Dataset::
+
+    chrX  151087187  151087355  A  0  -
+    chrX  151572400  151572481  B  0  +
+
+with Dataset1::
+
+    chr1  151242630  151242955  X  0  +
+    chr1  151271715  151271999  Y  0  +
+    chr1  151278832  151279227  Z  0  -
+    
+and with Dataset2::
+
+    chr2  100000030  200000955  P  0  +
+    chr2  100000015  200000999  Q  0  +
+
+will result in the following::
+
+    chrX  151087187  151087355  A  0  -
+    chrX  151572400  151572481  B  0  +
+    chr1  151242630  151242955  X  0  +
+    chr1  151271715  151271999  Y  0  +
+    chr1  151278832  151279227  Z  0  -
+    chr2  100000030  200000955  P  0  +
+    chr2  100000015  200000999  Q  0  +
+
+    </help>
+</tool>

--- a/tools/tophat/tophat2_wrapper.py
+++ b/tools/tophat/tophat2_wrapper.py
@@ -3,18 +3,76 @@
  wrapper script for running Tophat2
 """
 
-import sys, argparse, os, subprocess, shutil
+import sys, argparse, os, subprocess, shutil, tempfile
+
+
+# replace the .dat suffix of a file created by Galaxy so it can be recognized
+# by a tool such as Tophat
+def replace_filename_suffix( work_dir, input_filename ):
+    print input_filename
+    output_filename = input_filename 
+    # get the Galaxy filename without the path
+    galaxy_filename_basename = os.path.basename(input_filename)
+    # get the Galaxy filename suffix
+    galaxy_filename_suffix = os.path.splitext(galaxy_filename_basename)[1]
+    print '[' + galaxy_filename_suffix + ']'
+    # if the suffix is not .dat then assume the file has been directly supplied to Tophat
+    # and Tophat can work with it as it normally would 
+    if galaxy_filename_suffix == ".dat":
+        # see if the input file has ben gzipped
+        gunzip_test_cmd = "gunzip -t --suffix \".dat\" " + input_filename 
+        print gunzip_test_cmd      
+        status =subprocess.call(args = gunzip_test_cmd, stderr=subprocess.STDOUT, shell=True)
+        # if the file is a gzipped file then replace the .dat suffix with .fq.gz
+        # use .fq as part of the suffix becuase we assume that only fasta files are provided
+        # to Tophat
+        print work_dir
+        if status == 0:
+           filename_suffix = ".fq.gz"       
+        else:
+           filename_suffix = ".fq"       
+        # attach the new suffix to the original filename and create a new file name in a specified working directory
+        output_filename = os.path.join( work_dir, "%s%s" % ( galaxy_filename_basename, filename_suffix ) )
+        # create a symlink with the new file name to point to the original .dat input file for Tophat to use
+        # the new file extensions will enable Tophat to process the file appropriately
+        print "symlink " + input_filename  +  " " + output_filename
+        os.symlink( os.path.abspath(input_filename), output_filename)
+
+    print output_filename
+    return output_filename           
 
 def __main__():
     #Parse Command Line
     parser = argparse.ArgumentParser()
 
     parser.add_argument( '-p', '--pass_through', dest='pass_through_options', action='store', type=str, help='These options are passed through directly to Tophat2 without any modification.' )
+    parser.add_argument( '--input_filename1', dest='input_filename1', action='store', type=str, help='Fastq input filename' )
+    parser.add_argument( '--input_filename2', dest='input_filename2', action='store', type=str, help='Fastq input filename for reverse reads if available' )
 
  
     options = parser.parse_args()
     print options.pass_through_options
     cmd = options.pass_through_options
+
+    # create a temporary working directory where we can put a symlink
+    # to the real Galaxy input file which may not have the correct naming convention
+    # for Tophat
+    work_dir = tempfile.mkdtemp(dir="./", prefix="tophat2_work_")
+
+    print options.input_filename1
+    # remove quote characters and spaces from path filename 
+    filename = options.input_filename1.translate(None, '" ')
+    filename = replace_filename_suffix(work_dir, filename)
+    print filename
+    cmd = cmd + " " + filename
+
+    if options.input_filename2 != 'None': 
+       print options.input_filename2
+       # remove quote characters and spaces from path filename 
+       filename = options.input_filename2.translate(None, '" ')
+       filename = replace_filename_suffix(work_dir, filename)
+       print filename
+       cmd = cmd + " " + filename
 
     print "Command:"
     print cmd
@@ -23,6 +81,8 @@ def __main__():
         subprocess.check_output(args=cmd, stderr=subprocess.STDOUT, shell=True)
     except subprocess.CalledProcessError, e:
         print "!!!!!!!!!!!!Tophat2 ERROR: stdout output:\n", e.output
+
+    shutil.rmtree(work_dir)
 
 if __name__=="__main__": __main__()
 

--- a/tools/tophat/tophat2_wrapper.xml
+++ b/tools/tophat/tophat2_wrapper.xml
@@ -3,6 +3,7 @@
     <description>Gapped-read mapper for RNA-seq data</description>
     <version_command>tophat2 --version</version_command>
     <requirements>
+        <container type="docker">tophat2:2.0.9</container>
         <requirement type="package" version="0.1.18">samtools</requirement>
         <requirement type="package" version="2.1.0">bowtie2</requirement>
         <requirement type="package" version="2.0.9">tophat2</requirement>
@@ -112,24 +113,33 @@
           --rg-sample "$readGroup.rgsm"
         #end if
 
+
+
         ## Set index path, inputs and parameters specific to paired data.
         #if $singlePaired.sPaired != "single"
             -r $singlePaired.mate_inner_distance
             --mate-std-dev=$singlePaired.mate_std_dev
-            
             #if str($singlePaired.report_discordant_pairs) == "No":
                 --no-discordant
             #end if
+        #end if
 
+        ${index_path} 
+        '  <!--- end of pass through options -->
+
+        <!-- start input filename options -->
+        #if $singlePaired.sPaired != "single"
             #if $singlePaired.sPaired == "paired"
-              ${index_path} "$singlePaired.input1" "$singlePaired.input2"
+               --input_filename1 '  "$singlePaired.input1" '
+               --input_filename2 '  "$singlePaired.input2" '
             #else
-              ${index_path} "$singlePaired.input.forward" "$singlePaired.input.reverse"
+               --input_filename1 '  "$singlePaired.input.forward" '
+               --input_filename2 '  "$singlePaired.input.reverse" '
             #end if
         #else
-            ${index_path} "$singlePaired.input1"
+            --input_filename1 '  "$singlePaired.input1" '
         #end if
-        '  <!--- end of pass through options -->
+
     </command>
     
     <inputs>


### PR DESCRIPTION
Addition of a new tool that concatenates read files for input to Tophat2 in RNA-seq (or other tools in other workflows) and support in the tophat2 wrappers to replace input .dat file suffixes from Galaxy with .fq or .fq.gz that tophat2 can recognize. Also addition of a location file for human genome indexes used by bowtie2.
