### PR TITLE
simple galaxy tool to query variantDB

### DIFF
--- a/tools/variant_db/variant_db_client.py
+++ b/tools/variant_db/variant_db_client.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+import sys
+import argparse
+import requests
+import json
+# SearchVariantsResponse /variants/search
+variantSets = {
+"cervix": 3,
+"stomach": 15,
+"liver": 10,
+"bone": 9,
+"bladder": 7,
+"brain": 2,
+"head and neck": 6,
+"lung": 11,
+"blood": 0,
+"colorectal": 4,
+"skin": 17,
+"uterus": 16,
+"esophagus": 5,
+"pancreas": 13,
+"prostate": 14,
+"ovary": 12,
+"kidney": 8,
+"breast": 1
+}
+
+def variants_search(url, output, request):
+  f = open(output, "w")
+  r = requests.post(url + "/variants/search", data=request, headers={'content-type':'application/json'})
+  f.write(r.text)
+  f.close()
+
+if __name__ == "__main__":
+  parser = argparse.ArgumentParser(description='Variant DB GA4GH Communicator')
+  parser.add_argument('url', nargs='?', default=None,
+  help='Path to variant database.')
+  parser.add_argument('out', nargs='?', default=None,
+  help='File to save output.')
+  parser.add_argument('-vs', '--variantSetIds', dest='variantSetIds', nargs='+', type=str, required=True, default=None,
+  help='The IDs of the variant sets to search over.')
+  parser.add_argument('-vn', '--variantName', type=str, required=False, default=None,
+  help='Only return variants which have exactly this name.')
+  parser.add_argument('-c', '--callSetIds', nargs='+', type=str, required=False, default=None,
+  help='Only return variant calls which belong to call sets with these IDs. Leaving this blank returns all variant calls.')
+  parser.add_argument('-r', '--referenceName', type=str, required=True, default=None,
+  help='Only return variants on this reference.')
+  parser.add_argument('-st', '--start', type=long, required=False, default=None,
+  help='Required. The end of the window (0-based, exclusive) for which overlapping variants should be returned.')
+  parser.add_argument('-e', '--end', type=long, required=True, default=None,
+  help='The beginning of the window (0-based, inclusive) for which overlapping variants should be returned. Genomic positions are non-negative integers less than reference length. Requests spanning the join of circular genomes are represented as two requests one on each side of the join (position 0).')
+  parser.add_argument('-s', '--pageSize', type=int, required=False, default=None,
+  help='Specifies the maximum number of results to return in a single page. If unspecified, a system default will be used.')
+  parser.add_argument('-t', '--pageToken', type=int, required=False, default=None,
+  help='The continuation token, which is used to page through large result sets. To get the next page of results, set this parameter to the value of nextPageToken from the previous response.')
+  args = parser.parse_args()
+  in_url = vars(args).pop('url')
+  out = vars(args).pop('out')
+  vs = vars(args).pop('variantSetIds')
+  tile_vs = []
+  for v in vs:
+    tile_vs.append(variantSets[v])
+  vars(args)['variantSetIds'] = tile_vs
+  # SearchVariantsRequest
+  j = json.dumps(vars(args))
+  variants_search(in_url, out, j)

--- a/tools/variant_db/variant_db_client.xml
+++ b/tools/variant_db/variant_db_client.xml
@@ -5,7 +5,7 @@
     <requirement type="package">json</requirement>
   </requirements>
   <command interpreter="python">variant_db_client.py
-    http://localhost:5000
+    $url
     $output
       --variantSetIds $variant_select.variantSetId
       --referenceName $referenceName
@@ -27,26 +27,27 @@
     #end if
   </command>
   <inputs>
+    <param name="url" type="text" label="DB URL: " />
     <conditional name="variant_select">
       <param name="variantSetId" type="select" label="Variant Sets to Query: ">
-	<option value='cervix'>Cervix</option>
-	<option value='stomach'>Stomach</option>
-	<option value='liver'>Liver</option>
-	<option value='bone'>Bone</option>
-	<option value='bladder'>Bladder</option>
-	<option value='brain'>Brain</option>
-	<option value='head and neck'>Head and Neck</option>
-	<option value='lung'>Lung</option>
-	<option value='blood'>Blood</option>
-	<option value='colorectal'>Colorectal</option>
-	<option value='skin'>Skin</option>
-	<option value='uterus'>Uterus</option>
-	<option value='esophagus'>Esophagus</option>
-	<option value='pancreas'>Pancreas</option>
-	<option value='prostate'>Prostate</option>
-	<option value='ovary'>Ovary</option>
-	<option value='kidney'>Kidney</option>
-	<option value='breast'>Breast</option>
+      	<option value='cervix'>Cervix</option>
+      	<option value='stomach'>Stomach</option>
+      	<option value='liver'>Liver</option>
+      	<option value='bone'>Bone</option>
+      	<option value='bladder'>Bladder</option>
+      	<option value='brain'>Brain</option>
+      	<option value='head and neck'>Head and Neck</option>
+      	<option value='lung'>Lung</option>
+      	<option value='blood'>Blood</option>
+      	<option value='colorectal'>Colorectal</option>
+      	<option value='skin'>Skin</option>
+      	<option value='uterus'>Uterus</option>
+      	<option value='esophagus'>Esophagus</option>
+      	<option value='pancreas'>Pancreas</option>
+      	<option value='prostate'>Prostate</option>
+      	<option value='ovary'>Ovary</option>
+      	<option value='kidney'>Kidney</option>
+      	<option value='breast'>Breast</option>
       </param>
     </conditional>
     <param name="referenceName" type="text" label="Reference: "/>

--- a/tools/variant_db/variant_db_client.xml
+++ b/tools/variant_db/variant_db_client.xml
@@ -1,0 +1,63 @@
+<tool id="ga4gh" name="GA4GH">
+  <description>GA4GH SearchVariantRequest Generator</description>
+  <requirements>
+    <requirement type="package">requests</requirement>
+    <requirement type="package">json</requirement>
+  </requirements>
+  <command interpreter="python">variant_db_client.py
+    http://localhost:5000
+    $output
+      --variantSetIds $variant_select.variantSetId
+      --referenceName $referenceName
+      --end $end
+    #if $variantName
+      --variantName $variantName
+    #end if
+    #if $callSetIds
+      --callSetIds $callSetIds
+    #end if
+    #if $start
+      --start $start
+    #end if
+    #if $pageSize
+      --pageSize $pageSize
+    #end if
+    #if $pageToken
+      --pageToken $pageToken
+    #end if
+  </command>
+  <inputs>
+    <conditional name="variant_select">
+      <param name="variantSetId" type="select" label="Variant Sets to Query: ">
+	<option value='cervix'>Cervix</option>
+	<option value='stomach'>Stomach</option>
+	<option value='liver'>Liver</option>
+	<option value='bone'>Bone</option>
+	<option value='bladder'>Bladder</option>
+	<option value='brain'>Brain</option>
+	<option value='head and neck'>Head and Neck</option>
+	<option value='lung'>Lung</option>
+	<option value='blood'>Blood</option>
+	<option value='colorectal'>Colorectal</option>
+	<option value='skin'>Skin</option>
+	<option value='uterus'>Uterus</option>
+	<option value='esophagus'>Esophagus</option>
+	<option value='pancreas'>Pancreas</option>
+	<option value='prostate'>Prostate</option>
+	<option value='ovary'>Ovary</option>
+	<option value='kidney'>Kidney</option>
+	<option value='breast'>Breast</option>
+      </param>
+    </conditional>
+    <param name="referenceName" type="text" label="Reference: "/>
+    <param name="start" type="integer" value="0" label="Start Position" />
+    <param name="end" type="integer" value="0" label="End Position: " />
+    <param name="variantName" type="text" label="Variant Name: " optional="true" />
+    <param name="callSetIds" type="text" label="Callset Ids: " optional="true" />
+    <param name="pageSize" type="integer" value="0" label="Page Size" optional="true" />
+    <param name="pageToken" type="text" value="0" label="Page Token" optional="true" />
+  </inputs>
+  <outputs>
+  <data format="json" name="output" />
+  </outputs>
+</tool>


### PR DESCRIPTION
This tool performs a variants search request to tileDB and returns a json object to galaxy. The path to the database is hardcoded in the galaxy wrapper - that will need changed.

Only support to query one primary site at a time.
