### PR TITLE
Tophatpywrappersuffixfix

### DIFF
--- a/tools/tophat/tophat2_wrapper.py
+++ b/tools/tophat/tophat2_wrapper.py
@@ -9,24 +9,24 @@ import sys, argparse, os, subprocess, shutil, tempfile
 # replace the .dat suffix of a file created by Galaxy so it can be recognized
 # by a tool such as Tophat
 def replace_filename_suffix( work_dir, input_filename ):
-    print input_filename
+    print 'input filename:' + input_filename
     output_filename = input_filename 
     # get the Galaxy filename without the path
     galaxy_filename_basename = os.path.basename(input_filename)
     # get the Galaxy filename suffix
     galaxy_filename_suffix = os.path.splitext(galaxy_filename_basename)[1]
-    print '[' + galaxy_filename_suffix + ']'
+    print 'file name suffix' + '[' + galaxy_filename_suffix + ']'
     # if the suffix is not .dat then assume the file has been directly supplied to Tophat
     # and Tophat can work with it as it normally would 
-    if galaxy_filename_suffix == ".dat":
+    if galaxy_filename_suffix != ".gz" and galaxy_filename_suffix != ".fq":
         # see if the input file has ben gzipped
-        gunzip_test_cmd = "gunzip -t --suffix \".dat\" " + input_filename 
-        print gunzip_test_cmd      
+        gunzip_test_cmd = "gunzip -t --suffix \"" + galaxy_filename_suffix + "\" " + input_filename 
+        print 'gunzip cmd:' + gunzip_test_cmd      
         status =subprocess.call(args = gunzip_test_cmd, stderr=subprocess.STDOUT, shell=True)
         # if the file is a gzipped file then replace the .dat suffix with .fq.gz
         # use .fq as part of the suffix becuase we assume that only fasta files are provided
         # to Tophat
-        print work_dir
+        print 'work dir:' + work_dir
         if status == 0:
            filename_suffix = ".fq.gz"       
         else:

--- a/tools/tophat/tophat2_wrapper.py
+++ b/tools/tophat/tophat2_wrapper.py
@@ -6,7 +6,7 @@
 import sys, argparse, os, subprocess, shutil, tempfile
 
 
-# replace the .dat suffix of a file created by Galaxy so it can be recognized
+# replace the non .fq or .gz suffix of a file created by Galaxy so it can be recognized
 # by a tool such as Tophat
 def replace_filename_suffix( work_dir, input_filename ):
     print 'input filename:' + input_filename
@@ -16,14 +16,15 @@ def replace_filename_suffix( work_dir, input_filename ):
     # get the Galaxy filename suffix
     galaxy_filename_suffix = os.path.splitext(galaxy_filename_basename)[1]
     print 'file name suffix' + '[' + galaxy_filename_suffix + ']'
-    # if the suffix is not .dat then assume the file has been directly supplied to Tophat
-    # and Tophat can work with it as it normally would 
+    # if the suffix is not .gz or .fq then assume the file has been supplied to Tophat
+    # from another tool and add the appropriate suffix
+    # otherwise Tophat can work with it as it normally would 
     if galaxy_filename_suffix != ".gz" and galaxy_filename_suffix != ".fq":
         # see if the input file has ben gzipped
         gunzip_test_cmd = "gunzip -t --suffix \"" + galaxy_filename_suffix + "\" " + input_filename 
         print 'gunzip cmd:' + gunzip_test_cmd      
         status =subprocess.call(args = gunzip_test_cmd, stderr=subprocess.STDOUT, shell=True)
-        # if the file is a gzipped file then replace the .dat suffix with .fq.gz
+        # if the file is a gzipped file then replace the file suffix with .fq.gz
         # use .fq as part of the suffix becuase we assume that only fasta files are provided
         # to Tophat
         print 'work dir:' + work_dir
@@ -33,7 +34,7 @@ def replace_filename_suffix( work_dir, input_filename ):
            filename_suffix = ".fq"       
         # attach the new suffix to the original filename and create a new file name in a specified working directory
         output_filename = os.path.join( work_dir, "%s%s" % ( galaxy_filename_basename, filename_suffix ) )
-        # create a symlink with the new file name to point to the original .dat input file for Tophat to use
+        # create a symlink with the new file name to point to the original input file for Tophat to use
         # the new file extensions will enable Tophat to process the file appropriately
         print "symlink " + input_filename  +  " " + output_filename
         os.symlink( os.path.abspath(input_filename), output_filename)


### PR DESCRIPTION
changed the replace file suffix routine to add a .fq or .fq.gz suffix to input files that do not have one of these suffixes so that tophat can work with them. This is necessary when a tool in a workflow passes its output to tophat in Galaxy. Previously the script checked for a .dat suffix before adding the new suffix, but the Central Function uses a .o suffix, so now the script will handle any suffix.
