### PR TITLE
fix matplotlib xwindow issue

### DIFF
--- a/tools/multi_fastqc/multi_fastqc.py
+++ b/tools/multi_fastqc/multi_fastqc.py
@@ -5,6 +5,8 @@ from argparse import ArgumentParser
 import pandas as pd
 import subprocess
 import logging
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.backends.backend_pdf import PdfPages


### PR DESCRIPTION
Fix matplotlib so it doesn't use xwindow in order to generate pdf in galaxy.
