### PR TITLE
[DNM] Omics query tool (Python)

### DIFF
--- a/contrib/ccc_requirements.txt
+++ b/contrib/ccc_requirements.txt
@@ -2,3 +2,4 @@ requests==2.7.0
 pillow==2.8.2
 docopt==0.6.2
 pandas==0.16.2
+-e git://github.com/OHSUCompBio/labkey_multisite_query_tool.git#egg=labkey_multisite_query_tool

--- a/contrib/ccc_requirements.txt
+++ b/contrib/ccc_requirements.txt
@@ -1,5 +1,0 @@
-requests==2.7.0
-pillow==2.8.2
-docopt==0.6.2
-pandas==0.16.2
--e git://github.com/OHSUCompBio/labkey_multisite_query_tool.git#egg=labkey_multisite_query_tool

--- a/contrib/intel_env.sh
+++ b/contrib/intel_env.sh
@@ -38,3 +38,4 @@ export BCFTOOLS=/home/karthikg/broad/non_variant_db/bcftools/bcftools
 export TILEDB_IMPORT_EXE=/home/karthikg/broad/non_variant_db/variantDB/TileDB/example/bin/gt_example_loader
 export GCC49_PREFIX_PATH=/opt/gcc-4.9.1
 export SCATTER_GATHER_JAR_PATH=$GENOMICS_DIR/ohsu/dnapipeline/ScatterGather-1.0.0.jar
+export OMICS_QUERY_UI_TOOL=/cluster_share/ccc_sync/tools/omics-query-tool

--- a/tool-data/shared/labkey/omics.yml
+++ b/tool-data/shared/labkey/omics.yml
@@ -26,6 +26,9 @@ default:
       - fastq_forward_ccc_did
       - fastq_reverse_ccc_did
 
+    column_order:
+      - site_name
+
 servers:
 
   - host: http://localhost:9004/labkey/

--- a/tool-data/shared/labkey/omics.yml
+++ b/tool-data/shared/labkey/omics.yml
@@ -31,10 +31,10 @@ default:
 
 servers:
 
-  - host: http://localhost:9004/labkey/
+  - host: http://g1.spark0.intel.com:9090/labkey/
     custom_columns:
       site_name: Austin
 
-  - host: http://localhost:9004/labkey/
+  - host: http://g2.spark0.intel.com:9090/labkey/
     custom_columns:
       site_name: Boston

--- a/tool-data/shared/labkey/omics.yml
+++ b/tool-data/shared/labkey/omics.yml
@@ -1,0 +1,37 @@
+default:
+
+    project: ccc
+    schema: lists
+    query_name: genome_data
+
+    email: $LABKEY_USERNAME
+    password: $LABKEY_PASSWORD
+
+    aliases:
+      specimen_id/project_code: project_name
+      specimen_id/donor_id: donor_id
+      specimen_id/disease_state: specimen_classification
+      specimen_id/specimen_type: specimen_type
+      specimen_id/donor_gender: donor_gender
+      fastq_forward: fastq_forward_ccc_did
+      fastq_reverse: fastq_reverse_ccc_did
+
+    columns:
+      - project_name
+      - donor_id
+      - specimen_id
+      - specimen_classification
+      - speciment_type
+      - donor_gender
+      - fastq_forward_ccc_did
+      - fastq_reverse_ccc_did
+
+servers:
+
+  - host: http://localhost:9004/labkey/
+    custom_columns:
+      site_name: Austin
+
+  - host: http://localhost:9004/labkey/
+    custom_columns:
+      site_name: Boston

--- a/tool-data/shared/python_requirements/omics_data.txt
+++ b/tool-data/shared/python_requirements/omics_data.txt
@@ -1,0 +1,5 @@
+requests==2.7.0
+pillow==2.8.2
+docopt==0.6.2
+pandas==0.16.2
+git+git://github.com/OHSUCompBio/labkey_multisite_query_tool.git

--- a/tool_conf.xml
+++ b/tool_conf.xml
@@ -22,6 +22,7 @@
     <tool file="data_source/wormbase_test.xml" />
     <tool file="data_source/eupathdb.xml" />
     <tool file="data_source/hbvar.xml" />
+    <tool file="data_source/omics_data.xml" />
     <tool file="genomespace/genomespace_file_browser_prod.xml" />
     <tool file="genomespace/genomespace_importer.xml" />
     <tool file="validation/fix_errors.xml" />

--- a/tools/data_source/omics_data.xml
+++ b/tools/data_source/omics_data.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+
+<tool name="Omics Data" id="get_omics_data">
+  <!--
+      This tool assumes that there's a path ($OMICS_QUERY_UI_TOOL) that has
+      two directories:
+
+            - "html": the app for the UI tool that's copied to the output
+              of the tool.
+
+            - "venv": A virtual environment for installing dependencies from
+              $GALAXY_ROOT/tool-data/shared/python_requirements/omics_data.txt
+  -->
+
+  <description>
+    Query omics data across available DMS sources.
+  </description>
+  
+  <command>
+    <!--This is the YAML file containing the LabKey configuration. -->
+    export CONFIG_FILE=${__app__.config.tool_data_path}/shared/labkey/omics.yml;
+    echo \$CONFIG_FILE;
+
+    <!-- The UI is expecting our JSON dataset to be avaiable at
+         data/payload.json -->
+    export JSON_OUTPUT=${html_file.files_path}/data/payload.json;
+    echo \$JSON_OUTPUT;
+
+    <!-- Copy the omics query UI tool to the corresponding directory. Note that
+         we also copy index.html to our html_file path. -->
+    mkdir -p ${html_file.files_path}/data;
+    cp -R \$OMICS_QUERY_UI_TOOL/html/* ${html_file.files_path};
+    cp -R \$OMICS_QUERY_UI_TOOL/html/index.html ${html_file};
+
+    <!-- Call the LabKey query tool. -->
+    source \$OMICS_QUERY_UI_TOOL/venv/bin/activate;
+    labkey --config-file=\$CONFIG_FILE --output-format=json > \$JSON_OUTPUT;
+  </command>
+
+  <outputs>
+    <data format="html" name="html_file" label="Omics data selection tool" />
+  </outputs>    
+
+</tool>

--- a/tools/data_source/omics_data.xml
+++ b/tools/data_source/omics_data.xml
@@ -17,14 +17,11 @@
   </description>
   
   <command>
-    <!--This is the YAML file containing the LabKey configuration. -->
+    <!--This is the YAML file containing the LabKey configuration -->
     export CONFIG_FILE=${__app__.config.tool_data_path}/shared/labkey/omics.yml;
-    echo \$CONFIG_FILE;
 
-    <!-- The UI is expecting our JSON dataset to be avaiable at
-         data/payload.json -->
+    <!-- The UI is expecting our JSON dataset to be avaiable at data/payload.json -->
     export JSON_OUTPUT=${html_file.files_path}/data/payload.json;
-    echo \$JSON_OUTPUT;
 
     <!-- Copy the omics query UI tool to the corresponding directory. Note that
          we also copy index.html to our html_file path. -->


### PR DESCRIPTION
## Do not merge

This PR should be merged in the future when we switch over to using the Python-based LabKey multi-site query tool.
### What

This pull-request adds a new tool to Galaxy for query LabKey. There are two external dependencies introduced:
- [The Omics UI tool](https://github.com/Intel-HSS/ccc-ui-tool-omero-image-selection): An Angular app that presents the user with a UI to import data.
- [The LabKey Multi-Site Query Tool](https://github.com/OHSUCompBio/labkey_multisite_query_tool): A new implementation for querying LabKey.

When the tool gets kicked off, two things happen:
1. The build of the Omics UI tool (stored in [$OMICS_QUERY_UI_TOOL](https://github.com/Intel-HSS/galaxy/blob/omics-query-tool/contrib/intel_env.sh#L40)/html is [copied](https://github.com/Intel-HSS/galaxy/blob/omics-query-tool/tools/data_source/omics_data.xml#L28-L30) over to the output directory for the tool.
2. After activating the tool's virtual environment, the `labkey` command is [called](https://github.com/Intel-HSS/galaxy/blob/omics-query-tool/tools/data_source/omics_data.xml#L33-L34) to pipe output to the tool's expected JSON output.

From that point on, when a user views the output of the tool, they see the Angular app that is "hydrated" with data from the LabKey JSON payload:

![image](https://cloud.githubusercontent.com/assets/270691/8418799/511590b2-1e6a-11e5-9136-9715d1ac3c5b.png)

Users can search, sort, filter, and select datasets that they want to import into the current history:

![image](https://cloud.githubusercontent.com/assets/270691/8418817/684178d2-1e6a-11e5-862c-8b28650a5337.png)

When the user imports the datasets, there are two datasets associated for each row: a forward- and reverse-FastQ data file. These are loaded from the Shared Library and imported into the current history.
### Todo
- [x] fix "select-all" when filtered down on datasets
- [x] fix Austin not showing up
- [x] fix ips in the configuration
### Deploy Checklist
- [ ] Update the [tool config](https://github.com/Intel-HSS/galaxy/blob/omics-query-tool/tool-data/shared/labkey/omics.yml) to use production IPs.
- [ ] Create `/cluster_share/ccc_sync/tools/omics-query-tool` [shared directory](https://github.com/Intel-HSS/galaxy/blob/omics-query-tool/contrib/intel_env.sh#L40) (`$OMICS_QUERY_UI_TOOL`)
- [ ] Create a Python virtual environment in `$OMICS_QUERY_UI_TOOL/venv`.
- [ ] Run `source $OMICS_QUERY_UI_TOOL/venv/bin/activate && pip install -r $GALAXY_ROOT/tool-data/shared/python_requirements/omics_data.txt` to install tool dependencies into the tool's virtual environment.
- [ ] Create a build of [the Omics UI tool](https://github.com/Intel-HSS/ccc-ui-tool-omero-image-selection) and put it in `$OMICS_QUERY_UI_TOOL/html`
### How to test
1. Run the "Omics Data" tool found under "Get Data".
2. View the output of the tool.
3. Select a few datasets and click import.

The history should have twice as many datasets imported -- a forward and reverse FastQ datasets for each row.
