### PR TITLE
Setting sanitize_all_html to False to support styles for CIViC

### DIFF
--- a/universe_wsgi.ini.standalone
+++ b/universe_wsgi.ini.standalone
@@ -531,7 +531,7 @@ log_level = DEBUG
 # By default, all tool output served as 'text/html' will be sanitized
 # thoroughly. This can be disabled if you have special tools that require
 # unaltered output.
-#sanitize_all_html = True
+sanitize_all_html = False
 
 # By default Galaxy will serve non-HTML tool output that may potentially
 # contain browser executable JavaScript content as plain text. This will for


### PR DESCRIPTION
@kgururaj Please merge this if you think this change is acceptable. We can produce this nice output for CIViC only if this change is possible. 

![image](https://cloud.githubusercontent.com/assets/10712456/8488991/fddffc70-20cb-11e5-8e1b-32002d7271a8.png)
